### PR TITLE
add pro controller

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const HID = require("node-hid");
 const JoyConLeft = require("./joy-con-left");
 const JoyConRight = require("./joy-con-right");
+const ProCon = require("./pro-con");
 
 function listConnectedJoyCons() {
   const devices = HID.devices();
@@ -13,6 +14,8 @@ function listConnectedJoyCons() {
             return new JoyConLeft(device.path);
           } else if (device.productId === 8199) {
             return new JoyConRight(device.path);
+          } else if (device.productId === 8201) {
+            return new ProCon(device.path);
           } else {
             throw new Error("Unknown Joy-Con model");
           }

--- a/pro-con.js
+++ b/pro-con.js
@@ -25,8 +25,8 @@ class ProCon extends JoyCon {
       zr: false,
       analogStickLPress: false,
       analogStickRPress: false,
-      analogStickL: 130, // TODO: Need resarch.
-      analogStickR: 130, // TODO: Need resarch.
+      analogStickL: 130,
+      analogStickR: 130
     };
   }
 
@@ -55,8 +55,8 @@ class ProCon extends JoyCon {
       analogStickLPress: Boolean(bytes[2] & 0x04),
       analogStickRPress: Boolean(bytes[2] & 0x08),
 
-      analogStickL: bytes[5], // TODO: Need resarch.
-      analogStickR: bytes[9]  // TODO: Need resarch.
+      analogStickL: [bytes[5], bytes[7]],
+      analogStickR: [bytes[9], bytes[11]]
     };
   }
 }

--- a/pro-con.js
+++ b/pro-con.js
@@ -1,0 +1,64 @@
+const JoyCon = require("./joy-con");
+
+class ProCon extends JoyCon {
+  constructor(path = null) {
+    super(path);
+
+    this.side = null;
+
+    this.buttons = {
+      dpadUp: false,
+      dpadDown: false,
+      dpadLeft: false,
+      dpadRight: false,
+      a: false,
+      x: false,
+      b: false,
+      y: false,
+      minus: false,
+      plus: false,
+      screenshot: false,
+      home: false,
+      l: false,
+      r: false,
+      zl: false,
+      zr: false,
+      analogStickLPress: false,
+      analogStickRPress: false,
+      analogStickL: 130, // TODO: Need resarch.
+      analogStickR: 130, // TODO: Need resarch.
+    };
+  }
+
+  _buttonsFromInputReport3F(bytes) {
+    return {
+      dpadLeft: bytes[3] === 5 || bytes[3] === 6 || bytes[3] === 7,
+      dpadDown: bytes[3] === 3 || bytes[3] === 4 || bytes[3] === 5,
+      dpadUp: bytes[3] === 0 || bytes[3] === 1 || bytes[3] === 7,
+      dpadRight: bytes[3] === 1 || bytes[3] === 2 || bytes[3] === 3,
+
+      a: Boolean(bytes[1] & 0x02),
+      x: Boolean(bytes[1] & 0x08),
+      b: Boolean(bytes[1] & 0x01),
+      y: Boolean(bytes[1] & 0x04),
+
+      minus: Boolean(bytes[2] & 0x01),
+      plus: Boolean(bytes[2] & 0x02),
+      screenshot: Boolean(bytes[2] & 0x20),
+      home: Boolean(bytes[2] & 0x10),
+
+      l: Boolean(bytes[1] & 0x10),
+      zl: Boolean(bytes[1] & 0x40),
+      r: Boolean(bytes[1] & 0x20),
+      zr: Boolean(bytes[1] & 0x80),
+
+      analogStickLPress: Boolean(bytes[2] & 0x04),
+      analogStickRPress: Boolean(bytes[2] & 0x08),
+
+      analogStickL: bytes[5], // TODO: Need resarch.
+      analogStickR: bytes[9]  // TODO: Need resarch.
+    };
+  }
+}
+
+module.exports = ProCon;


### PR DESCRIPTION
I want to use a pro controller.（https://www.nintendo.co.jp/hardware/switch/accessories/）
I'm worried about the behavior of the analog stick. However, I confirmed the behavior of other buttons.

<pre>
const { listConnectedJoyCons } = require('./index.js');
const devices = listConnectedJoyCons();
const pro = devices[0].open();

[
  'dpadUp',
  'dpadDown',
  'dpadLeft',
  'dpadRight',
  'a',
  'x',
  'b',
  'y',
  'minus',
  'plus',
  'screenshot',
  'home',
  'l',
  'r',
  'zl',
  'zr',
  'analogStickLPress',
  'analogStickRPress',
  'analogStickL',
  'analogStickR'
].forEach((name) => {
  pro.on(`down:${name}`, () => {
    console.log(`down:${name}`);
  });

  pro.on(`up:${name}`, () => {
    console.log(`up:${name}`);
  });

  pro.on(`change:${name}`, (val) => {
    console.log(`change:${name}`, val);
  });
});
</pre>